### PR TITLE
Add POST wrapper for /debug/pprof/symbol

### DIFF
--- a/echopprof.go
+++ b/echopprof.go
@@ -14,6 +14,7 @@ func Wrap(e *echo.Echo) {
 	e.GET("/debug/pprof/cmdline", fromHandlerFunc(pprof.Cmdline).Handle)
 	e.GET("/debug/pprof/profile", fromHandlerFunc(pprof.Profile).Handle)
 	e.GET("/debug/pprof/symbol", fromHandlerFunc(pprof.Symbol).Handle)
+	e.POST("/debug/pprof/symbol", fromHandlerFunc(pprof.Symbol).Handle)
 }
 
 var Wrapper = Wrap


### PR DESCRIPTION
go tool pprof seems to want a POST handler here on Go 1.5.1
```
go tool pprof --alloc_objects localhost:8080/debug/pprof/heap
 
{"time":"2016-06-22T18:50:45-07:00","remote_ip":"127.0.0.1","method":"GET","uri":"/debug/pprof/heap","status":200, "latency":432,"latency_human":"432.532µs","rx_bytes":0,"tx_bytes":1266}
{"time":"2016-06-22T18:50:45-07:00","level":"ERROR","prefix":"echo","file":"echo.go","line":"230","message":"Method Not Allowed"}
{"time":"2016-06-22T18:50:45-07:00","remote_ip":"127.0.0.1","method":"POST","uri":"/debug/pprof/symbol","status":405, "latency":116,"latency_human":"116.077µs","rx_bytes":215,"tx_bytes":18}
```

With the POST handler everything is fine. Go 1.6 seems to use GET instead, but I can't find the change.
It looks like either one is valid? https://golang.org/src/net/http/pprof/pprof.go?s=5015:5038#L158
